### PR TITLE
Adding Huborg::Client#synchronize_mailmap!

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ client.audit_license
 The above script leverages Github's API to check each repository's
 license. Log as an error each repository that does not have a license.
 
+```ruby
+require 'huborg'
+# NOTE: You will need to include GITHUB_ACCESS_TOKEN in your ENV
+client = Huborg::Client.new(org_names: ["samvera"])
+client.synchronize_mailmap!(template: '/path/to/my/MAILMAP_TEMPLATE')
+```
+
+The above will take the given template (which confirms to [Git's .mailmap
+file format](https://www.git-scm.com/docs/git-check-mailmap), then
+iterates on all of the repositories, adding any non-duplicates, then
+writing back to the template before creating pull requests against
+each of the organization's non-archived repositories.
+
 **All of the commands have several parameters, many set to default values.**
 
 ## Prerequisites

--- a/Rakefile
+++ b/Rakefile
@@ -32,4 +32,13 @@ namespace :test do
     )
     client.audit_license
   end
+
+  task :mailmap do
+    require 'huborg'
+    client = Huborg::Client.new(
+      github_access_token: ENV.fetch("GITHUB_ACCESS_TOKEN"),
+      org_names: ENV.fetch("GITHUB_ORG_NAME")
+    )
+    client.synchronize_mailmap!(template: ENV.fetch("MAILMAP_TEMPLATE_FILENAME"))
+  end
 end


### PR DESCRIPTION
The method will take a given template (which confirms to [Git's
.mailmap file format](https://www.git-scm.com/docs/git-check-mailmap),
then iterates on all of the repositories, adding any non-duplicates,
then writing back to the template before creating pull requests against
each of the organization's non-archived repositories.