### PR TITLE
Highlighting links to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # huborg
 
-Code: [![Version](https://badge.fury.io/rb/huborg.png)](http://badge.fury.io/rb/huborg)
+Code: [![Version](https://badge.fury.io/rb/huborg.svg)](https://rubygems.org/gems/huborg)
 
-Docs: [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
+Docs: [![Code Documentation](https://img.shields.io/badge/CODE-Documentation-blue.svg)](https://www.rubydoc.info/gems/huborg/) [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 
 Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)

--- a/huborg.gemspec
+++ b/huborg.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/samvera-labs/huborg/"
   spec.metadata["changelog_uri"] = "https://github.com/samvera-labs/huborg/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/huborg/"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/huborg.rb
+++ b/lib/huborg.rb
@@ -395,7 +395,7 @@ module Huborg
         end
       end
       rels
-      logger.info "Finished rels[#{rel.inspect}] for '#{org.login}' with pattern #{repository_pattern.inspect}"
+      logger.info "Finished fetching rels[#{rel.inspect}] for '#{org.login}' with pattern #{repository_pattern.inspect}"
       if block_given?
         rels
       else


### PR DESCRIPTION
Prior to this commit, there was no indication as to where to go for
online API documentation. This commit remedies that.

As a bonus, I've switched the Badge Fury image from png to SVG, which
improved the legibility of the rendered image. The png was blurry and
looked odd beside the other SVGs.