### PR TITLE
Adding guidance on determining Semantic Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Below is the checklist:
 - [ ] Pull down the latest version of master
 - [ ] Update the Huborg::VERSION (in ./lib/huborg/version.rb); Remember, huborg
       uses [Semantic Versioning](https://semver.org). (_**NOTE:** Do not commit the version change_)
+      - [ ] To give some insight on what version to use, you can use `yard diff`. With a clean master branch, run `yard`. Then run `yard diff huborg-<Huborg::VERSION> .yardoc` (where Huborg::VERSION is something like 0.1.0 and `.yarddoc` is the output directory of `yard`).
 - [ ] Run `bundle exec rake changelog` to generate [CHANGELOG.md](./CHANGELOG.md)
 - [ ] Review the new Huborg::VERSION CHANGELOG.md entries as they might prompt
       you to consider a different version (e.g. what you thought was a bug fix


### PR DESCRIPTION
In looking further at `yard diff`, I discovered that you can compare
the generated `.yardoc` directory (or directories) against a built
gem.

The two gem version parameters can each either be a named gem version
OR a path to a generated `.yardoc`

See https://github.com/lsegal/yard/blob/8e82a8ab27f2e711bf555bb6ba0c037a1eb3ccfb/spec/cli/diff_spec.rb#L178-L179
for specs