### PR TITLE
Fixing gemspec's changelog_uri

### DIFF
--- a/huborg.gemspec
+++ b/huborg.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/samvera-labs/huborg/"
-  spec.metadata["changelog_uri"] = "https://github.com/samvera-labs/huborg/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/samvera-labs/huborg/blob/master/CHANGELOG.md"
   spec.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/huborg/"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Prior to this commit, the URI resulted in a "Page not Found". This
commit corrects the URI.